### PR TITLE
markdownからhtmlファイルの生成

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 **/*.rs.bk
+/posts

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
 /target
 **/*.rs.bk
+/source
 /posts
+/*.sh
+/shell
+/kaihi
+/blog

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,6 +70,11 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "itoa"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "lazy_static"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -149,7 +154,30 @@ dependencies = [
 name = "rustatic"
 version = "0.1.0"
 dependencies = [
+ "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "comrak 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.79 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "ryu"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "serde"
+version = "1.0.79"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "serde_json"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ryu 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.79 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -277,6 +305,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b957d88f4b6a63b9d70d5f454ac8011819c6efa7727858f458ab71c756ce2d3e"
 "checksum comrak 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6abe2e9e00dc442635a90dec412ca028d097dc5b0b9688f55906728de61fcdb9"
 "checksum entities 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b5320ae4c3782150d900b79807611a59a99fc9a1d61d686faafc24b93fc8d7ca"
+"checksum itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1306f3464951f30e30d12373d31c79fbd52d236e5e896fd92f96ec7babbbe60b"
 "checksum lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ca488b89a5657b0a2ecd45b95609b3e848cf1755da332a0da46e2b2b1cb371a7"
 "checksum libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)" = "76e3a3ef172f1a0b9a9ff0dd1491ae5e6c948b94479a3021819ba7d860c8645d"
 "checksum memchr 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4b3629fe9fdbff6daa6c33b90f7c08355c1aca05a3d01fa8063b822fcf185f3b"
@@ -287,6 +316,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
 "checksum regex 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "2069749032ea3ec200ca51e4a31df41759190a88edca0d2d86ee8bedf7073341"
 "checksum regex-syntax 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "747ba3b235651f6e2f67dfa8bcdcd073ddb7c243cb21c442fc12395dfcac212d"
+"checksum ryu 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7153dd96dade874ab973e098cb62fcdbb89a03682e46b144fd09550998d4a4a7"
+"checksum serde 1.0.79 (registry+https://github.com/rust-lang/crates.io-index)" = "84257ccd054dc351472528c8587b4de2dbf0dc0fe2e634030c1a90bfdacebaa9"
+"checksum serde_json 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)" = "d30ec34ac923489285d24688c7a9c0898d16edff27fc1f1bd854edeff6ca3b7f"
 "checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"
 "checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
 "checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,3 +5,6 @@ authors = ["uma0317 <blog3170@gmail.com>"]
 
 [dependencies]
 comrak = "0.3"
+serde = "1.0"
+serde_json = "1.0"
+clap = "2.32.0"

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,0 +1,48 @@
+use clap::{App, AppSettings, Arg, SubCommand};
+
+pub fn build() -> App<'static, 'static> {
+    App::new("clapex")
+        .version("0.1.0")                       // バージョン情報
+        .author("myname <myname@mail.com>")     // 作者情報
+        .about("Clap Example CLI")              // このアプリについて
+        .arg(Arg::with_name("pa")               // 位置引数を定義
+        .help("sample positional argument")     // ヘルプメッセージ
+        .required(true)                         // この引数は必須であることを定義
+        )
+        .arg(Arg::with_name("flg")              // フラグを定義
+            .help("sample flag")                // ヘルプメッセージ
+            .short("f")                         // ショートコマンド
+            .long("flag")                       // ロングコマンド
+        )
+        .arg(Arg::with_name("opt")              // オプションを定義
+            .help("sample option")              // ヘルプメッセージ
+            .short("o")                         // ショートコマンド
+            .long("opt")                        // ロングコマンド
+            .takes_value(true)                  // 値を持つことを定義
+        )
+        .subcommand(SubCommand::with_name("sub")// サブコマンドを定義
+            .about("sample subcommand")         // このサブコマンドについて
+            .arg(Arg::with_name("subflg")       // フラグを定義
+                .help("sample flag by sub")     // ヘルプメッセージ
+                .short("f")                     // ショートコマンド
+                .long("flag")                   // ロングコマンド
+            )
+        )
+        .subcommand(SubCommand::with_name("add")
+            .about("add folder to list")
+            .arg(Arg::with_name("Target Project path")
+                .help("Target Project path [\".\" = current path]")
+                .required(true)
+                .takes_value(true) 
+            )
+            .arg(Arg::with_name("New Boilerplate name")
+                .help("New Boilerplate name")
+                .takes_value(true) 
+            )
+            .arg(Arg::with_name("force")
+                .help("Overwrite if duplicates")
+                .short("f")
+                .long("force")
+            )
+        )
+}

--- a/src/generate/mod.rs
+++ b/src/generate/mod.rs
@@ -1,0 +1,26 @@
+use utils::*;
+use SOURCE_POSTS_PATH;
+
+use std::fs;
+use std::io;
+
+use std::io::BufReader;
+use std::io::prelude::*;
+
+pub fn generate_html_files() -> io::Result<()> {
+    println!("{}", SOURCE_POSTS_PATH);
+    for entry in fs::read_dir(SOURCE_POSTS_PATH)? {
+        // let html_contents = md_to_html(post);
+        let post = entry.unwrap();
+        let mut buf_reader = BufReader::new(fs::File::open(post.path())?);
+        let mut md_contents = String::new();
+        buf_reader.read_to_string(&mut md_contents)?;
+
+        let html_contents = md_to_html(&md_contents);
+        let full_file_name = post.file_name().into_string().unwrap();
+        let file_name: Vec<&str> = full_file_name.split(".md").collect();
+        // println!("{:?}", file_name);
+        create_html_file(file_name[0], &html_contents);
+    }
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,10 @@
+#[macro_use]
 extern crate comrak;
+extern crate clap;
 
 pub mod utils;
+pub mod generate;
+pub mod cli;
+
+pub static SOURCE_POSTS_PATH: &'static str = "source/_posts";
+pub static GENERATED_POSTS_PATH: &'static str = "posts";

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,10 @@
 extern crate rustatic;
+extern crate clap;
 
-use rustatic::utils;
+use rustatic::{ utils, cli };
+use clap::{App, Arg, SubCommand};
 
 fn main() {
-    
+    let matches = cli::build().get_matches();
+
 }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,5 +1,11 @@
 use comrak::{markdown_to_html, ComrakOptions};
 
+use std::{fs, io};
 pub fn md_to_html(md: &str) -> String {
     markdown_to_html(md, &ComrakOptions::default())
+}
+
+pub fn count_md_files() -> io::Result<usize> {
+    let paths = fs::read_dir("posts")?;
+    return Ok(paths.count())
 }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,11 +1,25 @@
 use comrak::{markdown_to_html, ComrakOptions};
 
-use std::{fs, io};
+use std::fs;
+use std::io;
+use std::io::Write;
+
+use {SOURCE_POSTS_PATH, GENERATED_POSTS_PATH};
+pub fn get_config() {
+
+}
+
 pub fn md_to_html(md: &str) -> String {
     markdown_to_html(md, &ComrakOptions::default())
 }
 
 pub fn count_md_files() -> io::Result<usize> {
-    let paths = fs::read_dir("posts")?;
+    let paths = fs::read_dir(SOURCE_POSTS_PATH)?;
     return Ok(paths.count())
+}
+
+pub fn create_html_file(name: &str, contents: &str) -> io::Result<()>{
+    let mut file = fs::File::create(format!("{}/{}.html",GENERATED_POSTS_PATH, name))?;
+    file.write_all(contents.as_bytes())?;
+    Ok(())
 }

--- a/tests/generate/mod.rs
+++ b/tests/generate/mod.rs
@@ -1,0 +1,6 @@
+use rustatic::generate;
+
+#[test]
+fn htmls_generate_test() {
+    generate::generate_html_files();
+}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,3 +1,4 @@
 extern crate rustatic;
 
 mod utils;
+mod generate;

--- a/tests/utils/md_to_html_test.rs
+++ b/tests/utils/md_to_html_test.rs
@@ -1,7 +1,0 @@
-use rustatic::utils;
-
-#[test]
-fn it_convert_md_to_html() {
-    assert_eq!(utils::md_to_html("Hello, **世界**!"),
-           "<p>Hello, <strong>世界</strong>!</p>\n");
-}

--- a/tests/utils/mod.rs
+++ b/tests/utils/mod.rs
@@ -1,1 +1,12 @@
-mod md_to_html_test;
+use rustatic::utils;
+
+#[test]
+fn it_convert_md_to_html() {
+    assert_eq!(utils::md_to_html("Hello, **世界**!"),
+           "<p>Hello, <strong>世界</strong>!</p>\n");
+}
+
+#[test]
+fn it_count_md_files() {
+    assert_eq!(utils::count_md_files().unwrap(), 3);
+}

--- a/tests/utils/mod.rs
+++ b/tests/utils/mod.rs
@@ -10,3 +10,8 @@ fn it_convert_md_to_html() {
 fn it_count_md_files() {
     assert_eq!(utils::count_md_files().unwrap(), 3);
 }
+
+#[test]
+fn html_generate_test() {
+    utils::create_html_file("test", "hi");
+}


### PR DESCRIPTION
- [x] mdファイル数える
- [x] mdからhtmlファイルを生成
- [ ] 作った日付でフォルダ分け
- [ ] ページネーション生成
- [ ] ヘッダー等共通部分生成
- [ ] mdをhtmlに変換し、その際共通部分を埋め込む
- [ ] cssの設定